### PR TITLE
Feat: Use persistentMap & remove string usage for number

### DIFF
--- a/contract/asconfig.json
+++ b/contract/asconfig.json
@@ -1,21 +1,24 @@
 {
     "targets": {
         "debug": {
+            "outFile": "build/main.wasm",
             "sourceMap": true,
-            "debug": true,
-            "transform": ["@massalabs/as-transformer"]
+            "debug": true
         },
         "release": {
+            "outFile": "build/main.wasm",
             "sourceMap": true,
             "optimizeLevel": 3,
             "shrinkLevel": 0,
             "converge": false,
-            "noAssert": false,
-            "transform": ["@massalabs/as-transformer"]
+            "noAssert": false
         }
     },
     "options": {
         "exportRuntime": true,
-        "bindings": "esm"
+        "bindings": "esm",
+        "transform": [
+            "@massalabs/as-transformer"
+        ]
     }
 }

--- a/contract/assembly/contracts/main.ts
+++ b/contract/assembly/contracts/main.ts
@@ -1,12 +1,19 @@
-import { 
-  Storage, 
-  Context, 
-  generateEvent, 
-  remainingGas, 
-  transferredCoins, 
-  createEvent, 
+import {
+  Context,
+  generateEvent,
+  remainingGas,
+  transferredCoins,
+  isAddressEoa,
+  transferCoins,
+  Address,
+  createEvent,
 } from '@massalabs/massa-as-sdk';
+import { PersistentMap } from '../libraries/PersistentMap';
 import { Args, stringToBytes } from '@massalabs/as-types';
+
+const COLOR = new PersistentMap<string, string>('color');
+const OWNER = new PersistentMap<string, string>('owner');
+const PRICE = new PersistentMap<string, u64>('price');
 
 // Constructor function for smart contract deployment
 export function constructor(_: StaticArray<u8>): void {
@@ -14,18 +21,22 @@ export function constructor(_: StaticArray<u8>): void {
   if (!Context.isDeployingContract()) {
     return;
   }
-  
+
   // Default values for a pixel
-  const defaultOwner = "not_yet_owned"; // Default owner before any purchase
-  const defaultColor = "FFFFFF"; // Default color for the pixels
-  const initialPrice = 0.1; // Initial price for each pixel
-  
+  const defaultOwner = Context.caller().toString(); // Default owner before any purchase
+  const defaultColor = 'FFFFFF'; // Default color for the pixels
+  const initialPrice = u64(10 ** 8); // Initial price for each pixel, 0.1 Massa = 10_000_000
+
+  assert(isAddressEoa(defaultOwner), 'Only EOA can deploy the contract');
+
   // Initialize 100x100 pixels with default values
   for (let x = 0; x < 100; x++) {
     for (let y = 0; y < 100; y++) {
       let key = `${x},${y}`; // Composite key for storage
-      let value = `${defaultColor}:${defaultOwner}:${initialPrice}`; // "color:owner:price" format
-      Storage.set(key, value); // Store the pixel data
+      // Store the pixel data
+      COLOR.set(key, defaultColor);
+      OWNER.set(key, defaultOwner);
+      PRICE.set(key, initialPrice);
     }
   }
 }
@@ -35,19 +46,13 @@ export function constructor(_: StaticArray<u8>): void {
  * @param _args Encoded arguments for the operation
  */
 export function changeMultiplePixelsColor(_args: StaticArray<u8>): void {
-  // Ensure there's at least one pixel and a color in the arguments
-  if (_args.length < 4) {
-    throw new Error("Missing arguments for changeMultiplePixelsColor function.");
-  }
-
-  // Create an event to indicate the operation is done
-  generateEvent(createEvent("Massa Place", ["done"]));
-
   // Decode the arguments
   let args = new Args(_args);
-  let numberOfPixelsToChange = parseFloat(args.nextString().expect('Missing number of pixels to change.'));
-  let successfulChanges: string[] = []; // Track successful color changes
-  let failedChanges: string[] = []; // Track failed color changes
+  // use i32 instead of string
+  let numberOfPixelsToChange = args
+    .nextI32()
+    .expect('Missing number of pixels to change.');
+  let callerAddress = Context.caller().toString();
 
   // Iterate through each pixel to change its color
   for (let i = 0; i < numberOfPixelsToChange; i++) {
@@ -58,169 +63,136 @@ export function changeMultiplePixelsColor(_args: StaticArray<u8>): void {
     let key = `${x},${y}`;
 
     // Check if the pixel exists
-    if (!Storage.has(key)) {
-      failedChanges.push(`Pixel at ${key} not found.`);
-      continue;
-    }
-
-    let value = Storage.get(key);
-    let parts = value.split(":");
-
-    // Check for data integrity
-    if (parts.length < 3) {
-      failedChanges.push(`Pixel data at ${key} is corrupted or missing information.`);
+    if (!COLOR.contains(key)) {
+      generateEvent(`Massa Place colorChangeError Pixel at ${key} not found.`);
       continue;
     }
 
     // Only the current owner can change the pixel color
-    let currentOwner = parts[1];
-    let price = parts[2]; // Keep the price as is
+    let currentOwner = OWNER.getSome(key, '').unwrap();
 
-    let callerAddress = Context.caller().toString();
-    if (callerAddress !== currentOwner || currentOwner === "not_yet_owned") {
-      failedChanges.push(`Unauthorized: Caller ${callerAddress} is not the owner of pixel at ${key}.`);
+    if (callerAddress !== currentOwner) {
+      generateEvent(
+        `Massa Place colorChangeError Unauthorized: Caller ${callerAddress} is not the owner of pixel at ${key}.`,
+      );
       continue;
     }
-    
+
     // Update the storage with the new color
-    Storage.set(key, `${newColor}:${currentOwner}:${price}`);
-    successfulChanges.push(`${key},${newColor}`);
+    COLOR.set(key, newColor);
+    generateEvent(createEvent("Massa Place", ["colorChange", `${key},${newColor}`]));
   }
-
-  // Generate events for successful and failed color changes
-  successfulChanges.forEach(change => generateEvent(createEvent("Massa Place", ["colorChange", change])));
-  failedChanges.forEach(change => generateEvent(createEvent("Massa Place", ["colorChangeError", change])));
 }
-
 
 // Modifies the function to change the price of multiple pixels
 export function setMultiplePixelsPrice(_args: StaticArray<u8>): void {
-  // Ensure sufficient arguments are passed
-  if (_args.length < 4) {
-    throw new Error("Missing arguments for setMultiplePixelsPrice function.");
-  }
-
   let args = new Args(_args);
   // Retrieve the number of pixels whose price will be changed
-  let numberOfPixelsToChangePrice = parseFloat(args.nextString().expect('Missing number of pixels to change price.'));
-  let successfulPriceChanges: string[] = []; // Tracks successful price updates
-  let failedPriceChanges: string[] = []; // Tracks failed attempts due to various reasons
+  let numberOfPixelsToChangePrice = args
+    .nextI32()
+    .expect('Missing number of pixels to change price');
+  let callerAddress = Context.caller().toString();
 
   // Iterate through each pixel to update its price
   for (let i = 0; i < numberOfPixelsToChangePrice; i++) {
     let x = args.nextU32().expect('Missing x coordinate.'); // X coordinate
     let y = args.nextU32().expect('Missing y coordinate.'); // Y coordinate
-    let newPrice = args.nextString().expect('Missing new price.'); // New price for the pixel
+    let newPrice = args.nextU64().expect('Missing new price.'); // New price for the pixel
 
     let key = `${x},${y}`; // Composite key based on coordinates
 
     // Verify pixel exists before attempting price update
-    if (!Storage.has(key)) {
-      failedPriceChanges.push(`Pixel at ${key} not found.`);
+    if (!COLOR.contains(key)) {
+      generateEvent(`Massa Place changePriceError Pixel at ${key} not found.`);
       continue;
     }
 
-    // Retrieve current pixel data
-    let value = Storage.get(key);
-    let parts = value.split(":");
-    // Ensure data integrity before proceeding
-    if (parts.length < 3) {
-      failedPriceChanges.push(`Pixel data at ${key} is corrupted or missing information.`);
-      continue;
-    }
-
-    let currentColor = parts[0]; // Current color
-    let currentOwner = parts[1]; // Current owner
-
-    let callerAddress = Context.caller().toString();
     // Update price only if the caller is the current owner
+    let currentOwner = OWNER.getSome(key, '').unwrap();
+
     if (callerAddress !== currentOwner) {
-      failedPriceChanges.push(`Unauthorized: Caller ${callerAddress} is not the owner of pixel at ${key}.`);
+      generateEvent(
+        `Massa Place changePriceError Unauthorized: Caller ${callerAddress} is not the owner of pixel at ${key}.`,
+      );
       continue;
     }
 
     // Successfully update the pixel's price
-    Storage.set(key, `${currentColor}:${currentOwner}:${newPrice}`);
-    successfulPriceChanges.push(`${key},${newPrice}`);
+    PRICE.set(key, newPrice);
+    generateEvent(createEvent("Massa Place", ["changePrice",`${key},${newPrice}`]));
   }
-
-  // Generate events for successful and failed price updates
-  successfulPriceChanges.forEach(change => generateEvent(createEvent("Massa Place", ["changePrice",change])));
-  failedPriceChanges.forEach(change => generateEvent(createEvent("test", [change])));
 }
-
 
 // Function to handle the buying of pixels by users
 export function buyPixels(_args: StaticArray<u8>): void {
   let args = new Args(_args);
   // Extract the number of pixels a user intends to buy from the arguments
-  let numberOfPixelsToBuy = parseFloat(args.nextString().expect('Missing number of pixels to buy.'));
+  let numberOfPixelsToBuy = args
+    .nextI32()
+    .expect('Missing number of pixels to buy');
+
   // Retrieve the total amount of coins transferred with the transaction
   let totalTransferredAmount = transferredCoins(); // Ensure the correct conversion for your case
   let totalProposedPrice: u64 = 0; // Sum of proposed prices for all pixels intended for purchase
-  let successfulPurchases: string[] = []; // Tracks successfully purchased pixels
-  let failedPurchases: string[] = []; // Tracks failed purchase attempts
   let refundAmount: u64 = 0; // Tracks the total amount that needs to be refunded
+  let buyerAddress = Context.caller().toString();
 
-  // First, calculate the total proposed price for all intended pixel purchases
-  for (let i = 0; i < numberOfPixelsToBuy; i++) {
-    args.nextU32(); // Skip over the x coordinate
-    args.nextU32(); // Skip over the y coordinate
-    let proposedPrice = parseFloat(args.nextString().expect('Missing proposed price.'));
-    totalProposedPrice += u64(proposedPrice);
-  }
-
-  // Reset args to read through the pixel details again for processing
-  args = new Args(_args);
-  args.nextString(); // Skip the first U32, which is the count of pixels to buy
-
-  // Verify if the total amount transferred covers the total proposed price
-  if (totalTransferredAmount < totalProposedPrice) {
-    throw new Error(`Not enough coins transferred: required ${totalProposedPrice}, but got ${totalTransferredAmount}.`);
-  }
+  assert(isAddressEoa(buyerAddress), 'Only EOA can buy pixels');
 
   // Process each pixel for purchase
   for (let i = 0; i < numberOfPixelsToBuy; i++) {
     let x = args.nextU32().expect('Missing x coordinate.');
     let y = args.nextU32().expect('Missing y coordinate.');
-    // Assume proposed price is a F64 for simplicity
-    let proposedPrice = u64(parseFloat(args.nextString().expect('Missing proposed price.')));
+    let proposedPrice = args.nextU64().expect('Missing proposed price.');
+    assert(
+      totalProposedPrice + proposedPrice >= totalProposedPrice,
+      'Math Overflow',
+    );
+    totalProposedPrice += proposedPrice;
 
     let key = `${x},${y}`;
 
     // Check if the specified pixel exists
-    if (!Storage.has(key)) {
-      failedPurchases.push(`Pixel at ${key} not found.`);
+    if (!COLOR.contains(key)) {
+      generateEvent(`Massa Place buyPixel Pixel at ${key} not found.`);
+      assert(refundAmount + proposedPrice >= refundAmount, 'Math Overflow');
       refundAmount += proposedPrice; // Add to the refund amount
       continue;
     }
 
-    let value = Storage.get(key);
-    let parts = value.split(":");
-    // Validate pixel data and proposed price before proceeding
-    if (parts.length < 3 || parts[2] === "not_for_sale" || u64(parseFloat(parts[2])) != proposedPrice) {
-      failedPurchases.push(`Pixel at ${key} cannot be bought for the proposed price: ${proposedPrice.toString()}.`);
+    let price = PRICE.get(key, 0); // Retrieve the price of the pixel
+    if (price === u64.MAX_VALUE || price !== proposedPrice) {
+      generateEvent(
+        `Massa Place buyPixel Pixel at ${key} cannot be bought for the proposed price: ${proposedPrice.toString()}.`,
+      );
+      assert(refundAmount + proposedPrice >= refundAmount, 'Math Overflow');
       refundAmount += proposedPrice; // Add to the refund amount
       continue;
     }
+
+    let currentOwner = OWNER.getSome(key, '').unwrap(); // Retrieve the current owner of the pixel
 
     // Update the pixel data to reflect the new owner and mark it as not for sale
-    let buyerAddress = Context.caller().toString();
-    Storage.set(key, "000000" + ":" + buyerAddress + ":not_for_sale");
-    successfulPurchases.push(`${key},${buyerAddress}.`);
+    OWNER.set(key, buyerAddress);
+    PRICE.set(key, u64.MAX_VALUE);
+    COLOR.set(key, '000000');
+
+    transferCoins(new Address(currentOwner), price); // Transfer the coins to the current owner
+
+    generateEvent(createEvent('Massa Place', ['buyPixel', `${key},${buyerAddress}`]));
   }
 
-  // Generate events for both successful and failed purchases
-  successfulPurchases.forEach(change => generateEvent(createEvent('Massa Place', ['buyPixel', change])));
-  failedPurchases.forEach(change => generateEvent(createEvent('test', ['error', change])));
+  assert(
+    totalTransferredAmount >= totalProposedPrice,
+    `Not enough coins transferred: required ${totalProposedPrice}, but got ${totalTransferredAmount}.`,
+  );
 
   // Simulate a refund if necessary
   if (refundAmount > 0) {
-    generateEvent(createEvent('test', ["Refund needed:", refundAmount.toString()]));
-    // The actual refund logic would depend on your specific blockchain environment
+    generateEvent(`test Refund needed: ${refundAmount.toString()}`);
+    transferCoins(new Address(buyerAddress), refundAmount);
   }
 }
-
 
 // Function to retrieve details of all pixels within the smart contract's storage
 export function getAllPixelsDetails(_args: StaticArray<u8>): StaticArray<u8> {
@@ -230,39 +202,35 @@ export function getAllPixelsDetails(_args: StaticArray<u8>): StaticArray<u8> {
   let startX = args.nextU32().expect('Missing starting x coordinate.');
   let startY = args.nextU32().expect('Missing starting y coordinate.');
   // Initialize a string to accumulate pixel details
-  let allPixelsDetails = "";
-  const delimiter = "|"; // Delimiter to separate pixel details in the string
+  let allPixelsDetails = '';
+  const delimiter = '|'; // Delimiter to separate pixel details in the string
   // Define a margin for remaining gas to ensure the function doesn't run out of gas
-  const SOME_MARGIN = u64(1200000000);
+  const SOME_MARGIN = u64(100_000_000); // To dertermine by test
 
   // Iterate over the pixel grid starting from the provided coordinates
   for (let x = startX; x < 100; x++) {
-    for (let y = (x === startX ? startY : 0); y < 100; y++) {
+    for (let y = x === startX ? startY : 0; y < 100; y++) {
       // Check if the remaining gas is below the defined margin
       if (remainingGas() < SOME_MARGIN) {
         // If gas is running low, return the accumulated pixel details to prevent transaction failure
-        generateEvent("Low gas - partial data sent");
-        allPixelsDetails += remainingGas().toString() + "+" + SOME_MARGIN.toString();
+        generateEvent('Low gas - partial data sent');
+        allPixelsDetails +=
+          remainingGas().toString() + '+' + SOME_MARGIN.toString();
         return stringToBytes(allPixelsDetails); // Convert string data to bytes for return
       }
 
       let key = `${x},${y}`; // Construct the storage key for the current pixel
-      if (Storage.has(key)) { // Check if the pixel exists in storage
-        let value = Storage.get(key); // Retrieve pixel data
-        let parts = value.split(":"); // Split the data into components
-        // Ensure the pixel data includes color, owner, and price
-        if (parts.length == 3) {
-          let color = parts[0]; // Pixel color
-          let owner = parts[1]; // Pixel owner
-          let price = parts[2]; // Pixel price
-          // Accumulate the details with the specified delimiter
-          allPixelsDetails += `${x},${y},${color},${owner},${price}${delimiter}`;
-        }
+      if (COLOR.contains(key)) {
+        let color = COLOR.get(key, 'FFFFFF'); // Pixel color
+        let owner = OWNER.get(key, 'not_yet_owned'); // Pixel owner
+        let price = PRICE.get(key, u64(10 ** 8)); // Pixel price
+        // Accumulate the details with the specified delimiter
+        allPixelsDetails += `${x},${y},${color},${owner},${price}${delimiter}`;
       }
     }
   }
   // After iterating through all pixels, append the remaining gas info to the details
-  allPixelsDetails += remainingGas().toString() + "+" + SOME_MARGIN.toString();
-  generateEvent("All pixels sent"); // Generate an event indicating all pixel details have been sent
+  allPixelsDetails += remainingGas().toString() + '+' + SOME_MARGIN.toString();
+  generateEvent('All pixels sent'); // Generate an event indicating all pixel details have been sent
   return stringToBytes(allPixelsDetails); // Convert the final string of pixel details into bytes and return
 }

--- a/contract/assembly/libraries/PersistentMap.ts
+++ b/contract/assembly/libraries/PersistentMap.ts
@@ -1,0 +1,268 @@
+/* eslint-disable max-len */
+import { Storage } from '@massalabs/massa-as-sdk';
+import {
+  wrapStaticArray,
+  bytesToI64,
+  f64ToBytes,
+  i64ToBytes,
+  stringToBytes,
+  unwrapStaticArray,
+  boolToByte,
+  bytesToString,
+  bytesToF64,
+  byteToBool,
+  Result,
+} from '@massalabs/as-types';
+
+export const _KEY_ELEMENT_SUFFIX = '::';
+
+/**
+ * This class is one of several convenience collections built on top of the `Storage` class
+ * It implements a map -- a persistent unordered map.
+ *
+ * To create a map
+ *
+ * ```ts
+ * let map = new PersistentMap<string, string>("m")  // choose a unique prefix per account
+ * ```
+ *
+ * To use the map
+ *
+ * ```ts
+ * map.set(key, value)
+ * map.get(key)
+ * ```
+ *
+ * IMPORTANT NOTES:
+ *
+ * (1) The Map doesn't store keys, so if you need to retrieve them, include keys in the values.
+ *
+ * (2) Since all data stored on the blockchain is kept in a single key-value store under the contract account,
+ * you must always use a *unique storage prefix* for different collections to avoid data collision.
+ *
+ * @typeParam K - The generic type parameter `K` can be any [valid AssemblyScript type](https://docs.assemblyscript.org/basics/types).
+ * @typeParam V - The generic type parameter `V` can be any [valid AssemblyScript type](https://docs.assemblyscript.org/basics/types).
+ *
+ * MISC:
+ *
+ * Original code from Near (https://github.com/near/near-sdk-as/blob/master/sdk-core/assembly/collections/persistentMap.ts)
+ */
+export class PersistentMap<K, V> {
+  private _elementPrefix: string;
+  private _size: usize;
+
+  /**
+   * Creates or restores a persistent map with a given storage prefix.
+   * Always use a unique storage prefix for different collections.
+   *
+   * Example
+   *
+   * ```ts
+   * let map = new PersistentMap<string, string>("m") // note the prefix must be unique (per Massa account)
+   * ```
+   * @param prefix - A prefix to use for every key of this map.
+   */
+  constructor(prefix: string) {
+    this._elementPrefix = prefix + _KEY_ELEMENT_SUFFIX;
+    this._size = 0;
+  }
+
+  /**
+   * @param key - Search key.
+   * @returns An internal string key for a given key of type K.
+   */
+  private _key(key: K): StaticArray<u8> {
+    // @ts-ignore: TODO: Add interface that forces all K types to have toString
+    return stringToBytes(this._elementPrefix + key.toString());
+  }
+
+  /**
+   * Checks whether the map contains a given key
+   *
+   * ```ts
+   * let map = new PersistentMap<string, string>("m")
+   *
+   * map.contains("hello")      // false
+   * map.set("hello", "world")
+   * map.contains("hello")      // true
+   * ```
+   *
+   * @param key - Key to check.
+   * @returns True if the given key present in the map.
+   */
+  contains(key: K): bool {
+    return Storage.has(this._key(key));
+  }
+
+  /**
+   * Returns the map size
+   *
+   * @example
+   * ```ts
+   * let map = new PersistentMap<string, string> ("m")
+   *
+   * map.size()
+   * ```
+   * @returns the map size
+   */
+  size(): usize {
+    return this._size;
+  }
+
+  /**
+   * Removes the given key and related value from the map
+   *
+   * ```ts
+   * let map = new PersistentMap<string, string>("m")
+   *
+   * map.set("hello", "world")
+   * map.delete("hello")
+   * ```
+   *
+   * Removes value and the key from the map.
+   * @param key - Key to remove.
+   */
+  delete(key: K): void {
+    Storage.del(this._key(key));
+    this._decreaseSize();
+  }
+
+  /**
+   * Increases the internal map size counter
+   * @param key - Key to remove.
+   */
+  _increaseSize(key: K): void {
+    if (!this.contains(key)) {
+      this._size += 1;
+    }
+  }
+
+  /**
+   * Decreases the internal map size counter
+   */
+  _decreaseSize(): void {
+    if (this._size > 0) {
+      this._size -= 1;
+    }
+  }
+
+  /**
+   * Retrieves the related value for a given key, or uses the `defaultValue` if not key is found
+   *
+   * ```ts
+   * let map = new PersistentMap<string, string>("m")
+   *
+   * map.set("hello", "world")
+   * let found = map.get("hello")
+   * let notFound = map.get("goodbye", "cruel world")
+   *
+   * assert(found == "world")
+   * assert(notFound == "cruel world")
+   * ```
+   *
+   * @param key - Key of the element.
+   * @param defaultValue - The default value if the key is not present.
+   * @returns Value for the given key or the default value.
+   */
+  get(key: K, defaultValue: V): V {
+    if (!this.contains(key)) {
+      return defaultValue;
+    }
+    if (isString<V>()) {
+      // @ts-ignore
+      return bytesToString(Storage.get(this._key(key)));
+    } else if (isInteger<V>()) {
+      // @ts-ignore
+      return bytesToI64(Storage.get(this._key(key)));
+    } else if (isFloat<V>()) {
+      // @ts-ignore
+      return bytesToF64(Storage.get(this._key(key)));
+    } else if (isBoolean<V>()) {
+      // @ts-ignore
+      return byteToBool(Storage.get(this._key(key)));
+    } else if (idof<V>() == idof<StaticArray<u8>>()) {
+      return Storage.get(this._key(key));
+    } else if (isArrayLike<V>()) {
+      // @ts-ignore
+      return wrapStaticArray(Storage.get(this._key(key)));
+    } else if (defaultValue instanceof Serializable) {
+      const result = defaultValue;
+      const res = defaultValue.deserialize(Storage.get(this._key(key)));
+      if (res.isOk()) {
+        return defaultValue;
+      } else {
+        return result;
+      }
+    } else {
+      // @ts-ignore
+      return defaultValue;
+    }
+  }
+
+  /**
+   * Retrieves a related value for a given key or fails assertion with "key not found"
+   *
+   * ```ts
+   * let map = new PersistentMap<string, string>("m")
+   *
+   * map.set("hello", "world")
+   * let result = map.getSome("hello")
+   * // map.getSome("goodbye")  // will throw with failed assertion
+   *
+   * assert(result == "world")
+   * ```
+   *
+   * @param key - Key of the element.
+   * @returns Value for the given key or the default value.
+   */
+  getSome(key: K, defaultValue: V): Result<V> {
+    if (!this.contains(key)) {
+      return new Result(<V>defaultValue, 'key not found');
+    }
+
+    const res = this.get(key, defaultValue);
+    return new Result(<V>res);
+  }
+
+  /**
+   * @example
+   * ```ts
+   * let map = new PersistentMap<string, string>("m")
+   *
+   * map.set("hello", "world")
+   * ```
+   *
+   * Sets the new value for the given key.
+   * @param key - Key of the element.
+   * @param value - The new value of the element.
+   */
+  set(key: K, value: V): Result<usize> {
+    // check for map size won't overflow
+    if (this._size >= Usize.MAX_VALUE) {
+      return new Result(this.size(), 'map size overflow');
+    }
+
+    this._increaseSize(key);
+
+    if (isString<V>()) {
+      Storage.set(this._key(key), stringToBytes(value as string));
+    } else if (isInteger<V>()) {
+      Storage.set(this._key(key), i64ToBytes(value as i64));
+    } else if (isFloat<V>()) {
+      Storage.set(this._key(key), f64ToBytes(value as f64));
+    } else if (isBoolean<V>()) {
+      Storage.set(this._key(key), boolToByte(value as boolean));
+    } else if (value instanceof StaticArray<u8>) {
+      Storage.set(this._key(key), value);
+    } else if (isArrayLike<V>()) {
+      Storage.set(this._key(key), unwrapStaticArray(value as Uint8Array));
+    } else if (value instanceof Serializable) {
+      Storage.set(this._key(key), value.serialize());
+    } else {
+      // @ts-ignore
+      Storage.set(this._key(key), value.toString());
+    }
+
+    return new Result(this.size());
+  }
+}

--- a/contract/assembly/tsconfig.json
+++ b/contract/assembly/tsconfig.json
@@ -1,14 +1,10 @@
 {
+  "compilerOptions": {
+    "strictPropertyInitialization": false,
+    "strictBindCallApply": false
+  },
   "extends": "assemblyscript/std/assembly.json",
   "include": [
-    "**/*.ts"
-  ],
-  "typedocOptions": {
-    "exclude": "assembly/**/__tests__",
-    "excludePrivate": true,
-    "excludeProtected": true,
-    "excludeExternals": true,
-    "includeVersion": true,
-    "skipErrorChecking": true
-  }
+    "./**/*.ts"
+  ]
 }

--- a/contract/package.json
+++ b/contract/package.json
@@ -20,7 +20,7 @@
     "license": "ISC",
     "devDependencies": {
         "@as-pect/cli": "^8.1.0",
-        "@assemblyscript/loader": "^0.27.2",
+        "@assemblyscript/loader": "^0.27.22",
         "@massalabs/as-transformer": "^0.3.2",
         "@massalabs/as-types": "^2.0.0",
         "@massalabs/eslint-config": "^0.0.10",
@@ -30,23 +30,17 @@
         "@massalabs/massa-web3": "^3.0.2",
         "@massalabs/prettier-config-as": "^0.0.2",
         "@protobuf-ts/plugin": "^2.9.1",
-        "@types/node": "^18.11.10",
-        "assemblyscript": "^0.27.2",
+        "@types/node": "^20.10.3",
+        "@types/yargs": "^17.0.32",
+        "assemblyscript": "^0.27.22",
         "assemblyscript-prettier": "^1.0.7",
-        "dotenv": "^16.0.3",
-        "prettier": "^2.8.1",
-        "tslib": "^2.4.0",
+        "dotenv": "^16.3.1",
+        "prettier": "^3.1.0",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.6.2",
         "tsx": "^4.7.0",
-        "typescript": "^4.8.4"
-    },
-    "overrides": {
-        "visitor-as": {
-            "assemblyscript": "$assemblyscript"
-        }
+        "typescript": "^5.3.2"
     },
     "type": "module",
-    "prettier": "@massalabs/prettier-config-as",
-    "engines": {
-        "node": ">=16"
-    }
+    "prettier": "@massalabs/prettier-config-as"
 }

--- a/front/src/Pixel.tsx
+++ b/front/src/Pixel.tsx
@@ -8,7 +8,7 @@ interface PixelProps {
     y: number; // The y coordinate of the pixel
     color: string; // The color of the pixel
     owner: string; // The owner of the pixel
-    price: number; // The price of the pixel
+    price: bigint; // The price of the pixel
   };
   isSelected: boolean; // Flag indicating if the pixel is selected
   onClick: (e: React.MouseEvent<HTMLDivElement>, pixel: PixelProps['pixel']) => void; // Function to handle click events on the pixel


### PR DESCRIPTION
- Use persistentMap for storage
- Remove string usage when dealing with number in SC
- update dependencies
- add overflow check in SC
- add transferCoins for refund
- add creator as defaultOwner
- fix price handling in sc: 1 Massa = 10**9 unit

TODO: 
- Probably adapt the front more 
- determine the minimum SOME_MARGIN possible by tests
- global tests
- probably need to fix the price on the front (it would be in nanoMassa, thus divide by 10**9)